### PR TITLE
対象のアニメ制御とバレットを当てて破壊する制御追加

### DIFF
--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 5826978746817539066}
   m_Layer: 0
   m_Name: Bullet
-  m_TagString: Untagged
+  m_TagString: Bullet
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -152,7 +152,7 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7046184766197172480}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   m_Radius: 9.450728
   m_Height: 28.305235

--- a/Assets/Prefabs/LOVEDUCK.prefab
+++ b/Assets/Prefabs/LOVEDUCK.prefab
@@ -107,6 +107,7 @@ GameObject:
   - component: {fileID: 251846744485988569}
   - component: {fileID: 251846744478573125}
   - component: {fileID: 4980791310284114911}
+  - component: {fileID: -5637155140847464176}
   m_Layer: 0
   m_Name: LOVEDUCK
   m_TagString: Untagged
@@ -163,6 +164,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 90f4bfd3f03908d459f0209b086ce405, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!136 &-5637155140847464176
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251846744485698617}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 5.2
+  m_Height: 10.4
+  m_Direction: 0
+  m_Center: {x: 0, y: 4.8, z: 1}
 --- !u!1 &251846744485698693
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/WaterProDaytime.prefab
+++ b/Assets/Prefabs/WaterProDaytime.prefab
@@ -59,7 +59,7 @@ Transform:
   m_GameObject: {fileID: 7955973124306221104}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 3.5, y: 3.5, z: 3.5}
   m_Children:
   - {fileID: 5963810813422917903}
   m_Father: {fileID: 0}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -195,7 +195,7 @@ GameObject:
   - component: {fileID: 96355230}
   m_Layer: 0
   m_Name: Camera
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -259,7 +259,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 96355229}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 7.2, z: -10}
+  m_LocalPosition: {x: 0, y: 1.69, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -668,6 +668,85 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1001 &1076962498
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7955973124306221104, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_Name
+      value: WaterProDaytime
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306221104, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7955973124306248720, guid: 64a0b22cf15a6764bbb8c597fd61ba4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 64a0b22cf15a6764bbb8c597fd61ba4a, type: 3}
 --- !u!1 &1767035336
 GameObject:
   m_ObjectHideFlags: 0
@@ -886,6 +965,7 @@ MonoBehaviour:
   bulletPrefab: {fileID: 5259978054940551747, guid: e22f0f867b3086a4e88ef66a8bfc7159,
     type: 3}
   arManager: {fileID: 322517391}
+  isDebugEditor: 1
 --- !u!4 &1983060754
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AnimalController.cs
+++ b/Assets/Scripts/AnimalController.cs
@@ -5,7 +5,31 @@ using DG.Tweening;
 
 public class AnimalController : MonoBehaviour
 {
+    private Animator anim;
+    private Tween tween;
+
     public void MoveAnimal() {
-        transform.DOMoveY(10, 3.0f).SetLoops(-1, LoopType.Yoyo).SetEase(Ease.Linear);
+        anim = GetComponent<Animator>();
+        anim.SetTrigger("jump");
+        tween = transform.DOMoveY(2.5f, 3.0f).SetEase(Ease.InBack)
+            .OnComplete(() => {
+                transform.DOMoveY(0, 3.0f).SetEase(Ease.InBack)
+                    .OnComplete(() => {
+                        Destroy(gameObject);
+                    });
+            });
+    }
+
+    private void OnTriggerEnter(Collider other) {
+        if (other.CompareTag("Bullet")) {
+            tween.Kill();
+
+            anim.ResetTrigger("jump");
+            anim.SetTrigger("stun");
+
+            Destroy(other.gameObject);
+
+            Destroy(gameObject, 1.0f);
+        }
     }
 }

--- a/Assets/Scripts/BulletGenerator.cs
+++ b/Assets/Scripts/BulletGenerator.cs
@@ -10,9 +10,17 @@ public class BulletGenerator : MonoBehaviour
     [SerializeField]
     private ARManager arManager;
 
+    public bool isDebugEditor;
+
+    void Start() {
+        if (isDebugEditor) {
+            arManager = null;
+        }
+    }
+
     void Update()
     {
-        if (arManager.currentARState == ARManager.ARState.Play) {
+        if ((arManager != null && arManager.currentARState == ARManager.ARState.Play) || isDebugEditor) {
             if (Input.GetMouseButtonDown(0)) {
                 GenerateBullet();
             }

--- a/Assets/Scripts/TargetGenerator.cs
+++ b/Assets/Scripts/TargetGenerator.cs
@@ -20,7 +20,6 @@ public class TargetGenerator : MonoBehaviour
     /// <returns></returns>
     public IEnumerator GenerateAnimals() {
         while (true) {
-
             Instantiate(animalPrefab, animalTran).MoveAnimal();
             yield return new WaitForSeconds(3.0f);
         }

--- a/Assets/StreamingAssets.meta
+++ b/Assets/StreamingAssets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20752009bcfe93d4a80eb7ffabbe7086
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Shootable
+  - Bullet
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
・生成されたアヒルを空中で一時停止する制御を追加。
・バレット(魚)をぶつけると破壊する処理を追加。
・アヒルのアニメーション制御を追加。ジャンプとぶつかった時のアニメ再生。

・バレットの発射位置やアヒルの生成位置は要調整。
・実機テスト、問題なし。

・デバッグ完了。