### PR TITLE
ステージ、および敵の一時停止機能を追加。

### DIFF
--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -90,9 +90,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7674911235460289466}
-  - component: {fileID: 1689246888042386805}
-  - component: {fileID: 5259978054940551747}
   - component: {fileID: 5826978746817539066}
+  - component: {fileID: -7940934483239891044}
   m_Layer: 0
   m_Name: Bullet
   m_TagString: Bullet
@@ -107,43 +106,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7046184766197172480}
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8222515777828201140}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
---- !u!54 &1689246888042386805
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7046184766197172480}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!114 &5259978054940551747
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7046184766197172480}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad2cf4c0b33f65f4a9dcbc16a1e079fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  shotSpeed: 500
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &5826978746817539066
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -158,3 +128,15 @@ CapsuleCollider:
   m_Height: 28.305235
   m_Direction: 0
   m_Center: {x: -0.31269073, y: 0, z: 0.9527159}
+--- !u!114 &-7940934483239891044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7046184766197172480}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90f4bfd3f03908d459f0209b086ce405, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -265,6 +265,85 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &222583737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 222583738}
+  - component: {fileID: 222583740}
+  - component: {fileID: 222583739}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &222583738
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222583737}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1808005587}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &222583739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222583737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Stop Motion
+--- !u!222 &222583740
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222583737}
+  m_CullTransparentMesh: 1
 --- !u!1 &322517386
 GameObject:
   m_ObjectHideFlags: 0
@@ -430,6 +509,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   txtDebugMessage: {fileID: 2110875510}
+  btnStopMotion: {fileID: 1808005584}
+  autoScroller: {fileID: 1062907694}
 --- !u!4 &510689137
 Transform:
   m_ObjectHideFlags: 0
@@ -725,6 +806,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 2110875512}
+  - {fileID: 1489302986}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -794,6 +876,18 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &1062907694 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3416244455845857279, guid: 88a210c838d0c514fa293d1e4d854015,
+    type: 3}
+  m_PrefabInstance: {fileID: 3416244457032987900}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb7a5f5966809cb448b4f240ffc57003, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1076962498
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -873,6 +967,42 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64a0b22cf15a6764bbb8c597fd61ba4a, type: 3}
+--- !u!1 &1489302985
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1489302986}
+  m_Layer: 5
+  m_Name: Buttons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1489302986
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1489302985}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1808005587}
+  m_Father: {fileID: 810483933}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 50, y: 50}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1568670064 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1734643098908750880, guid: 201ed0269e622f04690db9b99af07fb9,
@@ -1005,6 +1135,127 @@ Transform:
   m_Father: {fileID: 322517390}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1808005583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1808005587}
+  - component: {fileID: 1808005586}
+  - component: {fileID: 1808005585}
+  - component: {fileID: 1808005584}
+  m_Layer: 5
+  m_Name: btnStopMotion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1808005584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808005583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1808005585}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1808005585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808005583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1808005586
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808005583}
+  m_CullTransparentMesh: 1
+--- !u!224 &1808005587
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808005583}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 222583738}
+  m_Father: {fileID: 1489302986}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 739.6553, y: 602}
+  m_SizeDelta: {x: 771.311, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1833942391
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AnimalController.cs
+++ b/Assets/Scripts/AnimalController.cs
@@ -8,16 +8,40 @@ public class AnimalController : MonoBehaviour
     private Animator anim;
     private Tween tween;
 
+    private GameObject lookTarget;
+
     public void MoveAnimal() {
-        anim = GetComponent<Animator>();
-        anim.SetTrigger("jump");
-        tween = transform.DOMoveY(2.5f, 3.0f).SetEase(Ease.InBack)
-            .OnComplete(() => {
-                transform.DOMoveY(0, 3.0f).SetEase(Ease.InBack)
-                    .OnComplete(() => {
-                        Destroy(gameObject);
-                    });
-            });
+        //anim = GetComponent<Animator>();
+        //anim.SetTrigger("jump");
+        //tween = transform.DOMoveY(2.5f, 3.0f).SetEase(Ease.InBack)
+        //    .OnComplete(() => {
+        //        transform.DOMoveY(0, 3.0f).SetEase(Ease.InBack)
+        //            .OnComplete(() => {
+        //                Destroy(gameObject);
+        //            });
+        //    });
+
+        tween = transform.DOMove(lookTarget.transform.position, 5.0f)
+            .SetEase(Ease.Linear)
+            .OnComplete(() => { Destroy(gameObject); });
+    }
+
+    public void SetUpAnimalController(GameObject player) {
+        lookTarget = player;
+
+        MoveAnimal();
+    }
+
+    void Update() {
+
+        // ÉJÉÅÉâÇÃï˚å¸Çå¸ÇØÇÈ
+        if (lookTarget) {
+            Vector3 direction = lookTarget.transform.position - transform.position;
+            direction.y = 0;
+
+            Quaternion lookRotation = Quaternion.LookRotation(direction, Vector3.up);
+            transform.rotation = Quaternion.Lerp(transform.rotation, lookRotation, 0.1f);
+        }    
     }
 
     private void OnTriggerEnter(Collider other) {

--- a/Assets/Scripts/FieldAutoScroller.cs
+++ b/Assets/Scripts/FieldAutoScroller.cs
@@ -37,13 +37,17 @@ public class FieldAutoScroller : MonoBehaviour
 
         // ˆêŽž’âŽ~‚ÆÄŠJˆ—
         if (Input.GetKeyDown(KeyCode.Space)) {
-            if (isPause) {
-                transform.DOPlay();
-            } else if (!isPause && stopMotionCount > 0) {
-                transform.DOPause();
-                stopMotionCount--;
-            }
-            isPause = !isPause;
+            StopAndPlayMotion();
         }
+    }
+
+    public void StopAndPlayMotion() {
+        if (isPause) {
+            transform.DOPlay();
+        } else if (!isPause && stopMotionCount > 0) {
+            transform.DOPause();
+            stopMotionCount--;
+        }
+        isPause = !isPause;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -13,6 +13,8 @@ public class GameManager : MonoBehaviour {
     [SerializeField]
     private List<GameObject> gimmicksList = new List<GameObject>();
 
+    [SerializeField]
+    private GameObject player;
 
     IEnumerator Start() {
         yield return StartCoroutine(PreparateGame());
@@ -36,6 +38,7 @@ public class GameManager : MonoBehaviour {
     /// <param name="enemyEventTran"></param>
     public void GenerateEnemy(EventDataSO.EventData enemyEventData, Transform enemyEventTran) {
         GameObject enemy = Instantiate(enemyEventData.eventPrefab, enemyEventTran);
+        enemy.GetComponent<AnimalController>().SetUpAnimalController(player);
         enemiesList.Add(enemy);
     }
 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -8,12 +8,26 @@ public class UIManager : MonoBehaviour
     [SerializeField]
     private Text txtDebugMessage;
 
+    [SerializeField]
+    private Button btnStopMotion;
+
+    [SerializeField]
+    private FieldAutoScroller autoScroller;
+
+    void Start() {
+        btnStopMotion.onClick.AddListener(OnClickStopMotion);    
+    }
+
     /// <summary>
     /// デバッグ内容を画面表示
     /// </summary>
     /// <param name="message"></param>
     public void DisplayDebug(string message) {
         txtDebugMessage.text = message;
+    }
+
+    private void OnClickStopMotion() {
+        autoScroller.StopAndPlayMotion();
     }
 }
 


### PR DESCRIPTION
・カメラ(プレイヤー)は動けるが、ステージを一時停止する機能を追加。
　周囲を見回すことが可能になる。

・ボタン操作でゲームの一時停止機能を追加。指定回数制限機能を追加。
・Canvas にボタンを設置し、一時停止機能を端末でも利用できるように制御追加。

・敵の移動の制御を追加。
・一時停止の範囲をゲーム内の敵にも有効化。プレイヤーは動けるが敵が一時停止することで一方的に攻撃できる状況を作成。
　再開することで敵の移動も再開する制御を追加。

・UI に一時停止時の演出を作成して追加。
・合わせて残り使用回数とアイコンの表示を追加。
・デバッグ完了。

・実機テスト完了。